### PR TITLE
Added support for Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.2
+import PackageDescription
+
+let package = Package(
+    name: "ManagedAppConfigLib",
+    platforms: [
+        .macOS(.v10_10),
+        .iOS(.v11),
+        .tvOS(.v9),
+        .watchOS(.v2)
+    ],
+    products: [
+        .library(name: "ManagedAppConfigLib",
+                 targets: ["ManagedAppConfigLib"])
+    ],
+    targets: [
+        .target(
+            name: "ManagedAppConfigLib",
+            path: "Classes"
+        )
+    ]
+)


### PR DESCRIPTION
Swift Package Manager is now the recommended dependency manager for iOS.
I have added support for it.

https://swift.org/package-manager/