### PR TITLE
Fix CocoaPods iOS target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2023-08-11
+### Fixed
+- Updated podspec file to target iOS 9 and higher to work around a problem with CocoaPods and Xcode 14.3+ ([Issue #8](https://github.com/jamf/ManagedAppConfigLib/issues/8)) [@macblazer](https://github.com/macblazer).
+
+### Changed
+- Simplified the nested `Listener` type definition inside of the two property wrappers to be Swift 6 compatible.
+- To improve code security, all commits going forward now require a [verified signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+
 ## [1.1.1] - 2023-05-08
 ### Added
 - Added CODEOWNERS file.

--- a/ManagedAppConfigLib.podspec
+++ b/ManagedAppConfigLib.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = "ManagedAppConfigLib"
-  s.version      = "1.1.1"
+  s.version      = "1.1.2"
   s.summary      = "Simplify working with Managed App Configuration and Feedback."
 
   s.description  = <<-DESC
-                    The purpose of ManagedAppConfigLib is to make it easier to work with Apple's [Managed App Configuration](https://developer.apple.com/library/content/samplecode/sc2279/Introduction/Intro.html) by providing a couple property wrappers and an object-based approach.
+                    ManagedAppConfigLib makes it easier to work with Apple's [Managed App Configuration](https://developer.apple.com/library/content/samplecode/sc2279/Introduction/Intro.html) by providing a couple property wrappers and an object-based approach.
                    DESC
 
   s.homepage     = "https://appconfig.org/"

--- a/ManagedAppConfigLib.podspec
+++ b/ManagedAppConfigLib.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author       = "Kyle Hammond", "James Felton"
 
   s.swift_versions = "5.1"
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, "9.0" # Actually supports iOS 8, but CocoaPods issue #11839
   s.tvos.deployment_target = "10.2"
   s.macos.deployment_target = "11"
 

--- a/README.md
+++ b/README.md
@@ -86,3 +86,8 @@ ManagedAppConfig.shared.addAppConfigChangedHook(myClosure)
 let numberOfErrors = 0
 ManagedAppConfig.shared.updateValue(numberOfErrors, forKey: "errorCount")
 ```
+
+## Contributing
+
+This repository now requires verified signed commits.  You can find out more about
+[signing commits on GitHub Docs](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).

--- a/Sources/ManagedAppConfigLib/AppConfig.swift
+++ b/Sources/ManagedAppConfigLib/AppConfig.swift
@@ -16,7 +16,7 @@ import SwiftUI
 @available(macOS 11, iOS 14.0, tvOS 14.0, *)
 @propertyWrapper public struct AppConfig<Value>: DynamicProperty {
     // Very simple listener that observes AppConfig changes, and has a local copy of the AppConfig's value.
-    private final class Listener<Value>: ObservableObject {
+    private final class Listener: ObservableObject {
         var subscriber: NSObjectProtocol?
         var value: Value? {
             willSet {
@@ -45,7 +45,7 @@ import SwiftUI
     ///
     /// Thanks to `DynamicProperty` conformance, when this object sends it's `objectWillChange` message
     /// SwiftUI will redraw any views depending on this property wrapper.
-    @StateObject private var core = Listener<Value>()
+    @StateObject private var core = Listener()
     private let key: String
     private let defaults: UserDefaults
     private let defaultValue: Value

--- a/Sources/ManagedAppConfigLib/AppConfigPlain.swift
+++ b/Sources/ManagedAppConfigLib/AppConfigPlain.swift
@@ -16,7 +16,7 @@ import Foundation
 @available(macOS 11, iOS 7.0, tvOS 10.2, *)
 @propertyWrapper public struct AppConfigPlain<Value> {
     // Very simple listener that observes AppConfig changes, and updates it's internal copy of the value as needed.
-    private final class Listener<Value> {
+    private final class Listener {
         var subscriber: NSObjectProtocol?
         var value: Value?
 
@@ -38,7 +38,7 @@ import Foundation
     }
 
     /// This object is the dynamic listener for changes to the app config and storage for the value.
-    private var listener = Listener<Value>()
+    private var listener = Listener()
     private let defaultValue: Value
 
     /// The value from Managed App Configuration or the defaultValue provided to the initializer.


### PR DESCRIPTION
Fixes #8

Also makes a type nested inside a generic type simpler and compatible with Swift 6.  Added short "Contributing" section to the README file.